### PR TITLE
[BUGFIX] Remove dependancy on exif_imagetype

### DIFF
--- a/src/Files/OneFileInfo.php
+++ b/src/Files/OneFileInfo.php
@@ -67,8 +67,8 @@ class OneFileInfo implements FileInfo
     protected $folderCache = [];
 
     /**
-     * @param string $absoluteLocation 
-     * @param ?bool  $fileExists       
+     * @param string $absoluteLocation
+     * @param ?bool  $fileExists
      */
     public function __construct(string $absoluteLocation, ?bool $fileExists)
     {
@@ -120,13 +120,7 @@ class OneFileInfo implements FileInfo
 
     protected function isImage(string $filename): bool
     {
-        try {
-            $outcome = @exif_imagetype($filename) ? true : false;
-        } catch (Exception $e) {
-            $outcome = false;
-        }
-
-        return $outcome;
+        return ( strpos(mime_content_type($filename), 'image/') === 0 );
     }
 
     protected function addFileSystemDetails()


### PR DESCRIPTION
Update `isImage` function to more reliable method of looking at the file metadata to determine if it's an image instead of relying on exif_imagetype to be able to calculate the image dimensions.

Ref; https://stackoverflow.com/questions/15408125/php-check-if-file-is-an-image#comment76807395_15408184